### PR TITLE
[BUG] Scheduler will not start again after removing last job

### DIFF
--- a/src/BaldurToolkit.Cron/TaskScheduler.cs
+++ b/src/BaldurToolkit.Cron/TaskScheduler.cs
@@ -117,7 +117,7 @@ namespace BaldurToolkit.Cron
 
         private void StartThread()
         {
-            if (this.timerThread == null)
+            if (this.timerThread == null || this.isRunning == false)
             {
                 this.isRunning = true;
                 this.timerThreadExitResetEvent = new ManualResetEvent(false);


### PR DESCRIPTION
Fixed bug when last job is removed and scheduler will not execute worker method again after adding new jobs